### PR TITLE
Bump Dockerfile image to Ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 as build-image
+FROM ubuntu:20.04 as build-image
 
 # Install python and other dependencies
 RUN apt-get update && apt-get install -y python3 python3-pip


### PR DESCRIPTION
Bump Dockerfile image to Ubuntu 20.04 to be able to build correctly on all arch types