### PR TITLE
Update machine manager to work with uarch

### DIFF
--- a/grpc-cartesi-machine/src/lib.rs
+++ b/grpc-cartesi-machine/src/lib.rs
@@ -26,6 +26,9 @@ use cartesi_grpc_interfaces::grpc_stubs::cartesi_machine::*;
 use conversions::*;
 use tonic::Response;
 
+pub const CM_UARCH_BREAK_REASON_REACHED_TARGET_CYCLE: u64 = 0;
+pub const CM_UARCH_BREAK_REASON_HALTED: u64 = 1;
+
 #[derive(Debug, Default)]
 struct GrpcCartesiMachineError {
     message: String,
@@ -704,6 +707,20 @@ impl GrpcCartesiMachineClient {
         let request = RunRequest { limit };
         let response = self.client.run(request).await?;
         Ok(response.into_inner())
+    }
+
+    /// Run remote machine to maximum limit ucycle
+    pub async fn run_uarch(&mut self, limit: u64) -> Result<RunUarchResponse, Box<dyn std::error::Error>> {
+        let request = RunUarchRequest { limit };
+        let response: Response<RunUarchResponse> = self.client.run_uarch(request).await?;
+        Ok(response.into_inner())
+    }
+
+    // Reset state of uarch machine
+    pub async fn reset_uarch_state(&mut self) -> Result<Void, Box<dyn std::error::Error>> {
+        let request = tonic::Request::new(Void {});
+        self.client.reset_uarch_state(request).await?;
+        Ok(Void {})
     }
 
     /// Serialize entire remote machine state to directory on cartesi machine server host

--- a/tests/demo-machine-manager-client/src/main.rs
+++ b/tests/demo-machine-manager-client/src/main.rs
@@ -222,6 +222,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let request = tonic::Request::new(SessionRunRequest {
             session_id: session_id.to_string(),
             final_cycles: vec![20],
+            final_ucycles: vec![],
         });
         let response = client.session_run(request).await?;
         if let Some(one_of) = response.into_inner().run_oneof {

--- a/tests/rust-test-client/features/session_get_proof.feature
+++ b/tests/rust-test-client/features/session_get_proof.feature
@@ -13,11 +13,33 @@ Feature: SessionGetProof feature
 
     Scenario Outline: asking for proofs with different parameters
         Given machine manager server is up
-        And a machine manager server with a machine executed for <cycle> final cycles
-        When the machine manager server asks machine for proof on cycle <cycle> for address <address> with log2_size <size>
+        And a machine manager server with a machine executed for <cycle> final cycles and <ucycle> final ucycles
+        When the machine manager server asks machine for proof on cycle <cycle> and ucycle <ucycle> for address <address> with log2_size <size>
         Then server returns correct proof
 
         Examples:
-            | cycle |        address      | size |
-            |  30   |          288        |  3   |
-            |  30   |          288        |  4   |
+            | cycle | ucycle |  address  | size |
+            |  30   |   60   |    288    |  3   |
+            |  30   |   60   |    288    |  4   |
+
+    Scenario Outline: asking for proof on invalid cycle
+
+        Given machine manager server is up
+        And a machine manager server with a machine executed for 20 final cycles and 15 final ucycles
+        When the machine manager server asks machine for proof on cycle <cycle> and ucycle 15 for address <address> with log2_size <size>
+        Then machine manager server returns an InvalidArgument error
+
+        Examples:
+            | cycle | address| size |
+            |   5   |   288  |  3   |
+
+     Scenario Outline: asking for proof on invalid cycle
+
+        Given machine manager server is up
+        And a machine manager server with a machine executed for 20 final cycles and 15 final ucycles
+        When the machine manager server asks machine for proof on cycle 20 and ucycle <ucycle> for address <address> with log2_size <size>
+        Then machine manager server returns an InvalidArgument error
+
+        Examples:
+            | ucycle | address| size |
+            |   5    |   288  |  3   |

--- a/tests/rust-test-client/features/session_read_write_memory.feature
+++ b/tests/rust-test-client/features/session_read_write_memory.feature
@@ -13,25 +13,25 @@ Feature: SessionReadWriteMemory feature
 
     Scenario Outline: read from pristine machine
         Given machine manager server is up
-        And a machine manager server with a machine executed for <cycle> final cycles
-        When client asks server to read memory on cycle <cycle>, starting on address <address> for length <length>
+        And a machine manager server with a machine executed for <cycle> final cycles and <ucycle> final ucycles
+        When client asks server to read memory on cycle <cycle> and ucycle <ucycle>, starting on address <address> for length <length>
         Then server returns read bytes <bytes>
 
         Examples:
-            | cycle |        address      | length |              bytes               |
-            |   1   | 36028797018963970 |   16   | 00000000000000000000000000000000 |
-            |  30   | 36028797018963970 |   16   | 00000000000000000000000000000000 |
+            | cycle | ucycle |      address      | length |              bytes               |
+            |   1   |   200    | 36028797018963970 |   16   | 00000000000000000000000000000000 |
+            |  30   |   400   | 36028797018963970 |   16   | 00000000000000000000000000000000 |
 
     Scenario Outline: read written value
         Given machine manager server is up
-        And a machine manager server with a machine executed for <cycle> final cycles
-        And the write request executed for cycle <cycle>, starting address <address> and data <data>
-        When client asks server to read memory on cycle <cycle>, starting on address <address> for length <length>
+        And a machine manager server with a machine executed for <cycle> final cycles and <ucycle> final ucycles
+        And the write request executed for cycle <cycle> and ucycle <ucycle>, starting address <address> and data <data>
+        When client asks server to read memory on cycle <cycle> and ucycle <ucycle>, starting on address <address> for length <length>
         Then server returns read bytes <bytes>
 
         Examples:
-            | cycle |       address       | length |    data    |             bytes                |
-            |  30   | 36028797018963970 |   16   | HELLOWORLD | 48454C4C4F574F524C44000000000000 |
+            | cycle | ucycle |      address       | length |    data    |             bytes                |
+            |  30   |  150   |  36028797018963970 |   16   | HELLOWORLD | 48454C4C4F574F524C44000000000000 |
 
     Scenario Outline: read on invalid cycle
 
@@ -40,13 +40,24 @@ Feature: SessionReadWriteMemory feature
         # session cycle argument, return error. SessionRun request should be used to run machine to particular cycle.
 
         Given machine manager server is up
-        And a machine manager server with a machine executed for 20 final cycles
-        When client asks server to read memory on cycle <cycle>, starting on address <address> for length <length>
+        And a machine manager server with a machine executed for 20 final cycles and 40 final ucycles
+        When client asks server to read memory on cycle <cycle> and ucycle 40, starting on address <address> for length <length>
         Then machine manager server returns an InvalidArgument error
 
         Examples:
-            | cycle |        address      | length |
+            | cycle |      address      | length |
             |   5   | 36028797018963970 |   16   |
+
+    Scenario Outline: read on invalid ucycle
+
+        Given machine manager server is up
+        And a machine manager server with a machine executed for 20 final cycles and 40 final ucycles
+        When client asks server to read memory on cycle 20 and ucycle <ucycle>, starting on address <address> for length <length>
+        Then machine manager server returns an InvalidArgument error
+
+        Examples:
+            | ucycle |      address      | length |
+            |   5    | 36028797018963970 |   16   |
 
     Scenario Outline: write on invalid cycle
 
@@ -54,10 +65,21 @@ Feature: SessionReadWriteMemory feature
         # session cycle argument, return error. SessionRun request should be used to run machine to particular cycle.
 
         Given machine manager server is up
-        And a machine manager server with a machine executed for 20 final cycles
-        When client asks server to write data <data> on cycle <cycle>, starting on address <address>
+        And a machine manager server with a machine executed for 20 final cycles and 15 final ucycles
+        When client asks server to write data <data> on cycle <cycle> and ucycle 15, starting on address <address>
         Then machine manager server returns an InvalidArgument error
 
         Examples:
-            | cycle |        address      |    data    |
+            | cycle |        address    |    data    |
             |   5   | 36028797018963970 | HELLOWORLD |
+
+    Scenario Outline: write on invalid ucycle
+
+        Given machine manager server is up
+        And a machine manager server with a machine executed for 20 final cycles and 15 final ucycles
+        When client asks server to write data <data> on cycle 20 and ucycle <ucycle>, starting on address <address>
+        Then machine manager server returns an InvalidArgument error
+
+        Examples:
+            | ucycle |        address    |    data    |
+            |   5    | 36028797018963970 | HELLOWORLD |

--- a/tests/rust-test-client/features/session_run.feature
+++ b/tests/rust-test-client/features/session_run.feature
@@ -15,8 +15,10 @@ Feature: SessionRun feature
         Given machine manager server is up
         And a pristine machine manager server session
         And the cycles array 0,15,30,45,60 to run the machine
+        And the ucycles array 100,0,150,0,100 to run the machine
         When client asks server to run session
-        Then server returns correct machine hashes
+        Then server returns correct session cycle 60 and ucycle 100 
+        And server returns correct machine hashes
 
     Scenario: run with rollback forcing
 
@@ -25,10 +27,12 @@ Feature: SessionRun feature
 
         Given machine manager server is up
         And a pristine machine manager server session
-        And the machine executed with cycles 0,30,60
+        And the machine executed with cycles 0,30,60 and ucycles 200,400,0
         And the cycles array 15,30,45 to run the machine
+        And the ucycles array 150,0,300 to run the machine
         When client asks server to run session
-        Then server returns correct machine hashes
+        Then server returns correct session cycle 45 and ucycle 300 
+        And server returns correct machine hashes
 
     Scenario: run with recreation forcing
 
@@ -37,10 +41,12 @@ Feature: SessionRun feature
 
         Given machine manager server is up
         And a pristine machine manager server session
-        And the machine executed with cycles 0,30,60
+        And the machine executed with cycles 0,30,60 and ucycles 200,400,0
         And the cycles array 1,5,10 to run the machine
+        And the ucycles array 150,0,300 to run the machine
         When client asks server to run session
-        Then server returns correct machine hashes
+        Then server returns correct session cycle 10 and ucycle 300 
+        And server returns correct machine hashes
 
     Scenario: run with no need for any special effort
 
@@ -48,14 +54,23 @@ Feature: SessionRun feature
 
         Given machine manager server is up
         And a pristine machine manager server session
-        And the machine executed with cycles 0,30,60
+        And the machine executed with cycles 0,30,60 and ucycles 200,400,0
         And the cycles array 15 to run the machine
+        And the ucycles array 50 to run the machine
         When client asks server to run session
-        Then server returns correct machine hashes
+        Then server returns correct session cycle 15 and ucycle 50 
+        And server returns correct machine hashes
+
 
     Scenario: long run
+
+        # Run uarch machine until it halts and increment session cycle value.
+
         Given machine manager server is up
         And a pristine machine manager server session
         And the cycles array 500000000 to run the machine
+        And the ucycles array 700000000 to run the machine
         When client asks server to run session
-        Then server returns correct machine hashes
+        Then server returns correct session cycle 500000001 and ucycle 0
+        And server returns correct machine hashes
+

--- a/tests/rust-test-client/features/session_step.feature
+++ b/tests/rust-test-client/features/session_step.feature
@@ -21,16 +21,17 @@ Feature: SessionStep feature
         #   cycle = initial cycle.
 
         Given machine manager server is up
-        And a machine manager server with a machine executed for <cycle> final cycles
-        When the machine manager server asks machine to step on initial cycle <cycle>
-        Then server returns correct access log
+        And a machine manager server with a machine executed for <cycle> final cycles and <ucycle> final ucycles
+        When the machine manager server asks machine to step on initial cycle <cycle> and initial ucycle <ucycle>
+        Then machine manager server returns correct session cycle <result_cycle> and ucycle <result_ucycle>
+        And server returns correct access log
 
         Examples:
-            | cycle |
-            |   1   |
-            |   21  |
-            |   35  |
-            |   30  |
+            | cycle | ucycle | result_cycle | result_ucycle |
+            |   1   |   1    |      1       |      2        |
+            |   21  |   101  |      21      |      102      |
+            |   35  |   250  |      35      |      251      |
+            |   30  |   500  |      30      |      501      |
 
     Scenario Outline: step on invalid cycle
 
@@ -39,11 +40,17 @@ Feature: SessionStep feature
         # session cycle argument, return error. SessionRun request should be used to run machine to particular cycle.
 
         Given machine manager server is up
-        And a machine manager server with a machine executed for <cycle> final cycles
-        When the machine manager server asks machine to step on initial cycle <cycle>
-        #Then machine manager server returns an Internal error
-        Then server returns correct access log
+        And a machine manager server with a machine executed for 20 final cycles and 300 final ucycles
+        When the machine manager server asks machine to step on initial cycle 15 and initial ucycle 300
+        Then machine manager server returns an InvalidArgument error
 
-        Examples:
-            | cycle |
-            |   20  |
+    Scenario Outline: step on invalid ucycle
+
+        # For rust machine manager:
+        # For operations ReadMemory/WriteMemory/Step/GetProof, in case where cycle argument is not equal to current
+        # session ucycle argument, return error. SessionRun request should be used to run machine to particular ucycle.
+
+        Given machine manager server is up
+        And a machine manager server with a machine executed for 20 final cycles and 300 final ucycles
+        When the machine manager server asks machine to step on initial cycle 20 and initial ucycle 150
+        Then machine manager server returns an InvalidArgument error

--- a/tests/rust-test-client/features/session_store_load.feature
+++ b/tests/rust-test-client/features/session_store_load.feature
@@ -16,5 +16,5 @@ Feature: SessionStoreLoad feature
         And a pristine machine manager server session
         When asking machine manager server to store the machine in a directory /stored_machine
         Then machine manager server is able to load machine from this directory correctly
-        And machine manager server is able to execute this machine for 60 cycles
+        And machine manager server is able to execute this machine for 60 cycles and 150 ucycles
         And server returns correct machine hashes

--- a/tests/rust-test-client/tests/steps/session_get_proof.rs
+++ b/tests/rust-test-client/tests/steps/session_get_proof.rs
@@ -35,12 +35,13 @@ pub fn steps() -> Steps<TestWorld> {
     let mut steps: Steps<TestWorld> = Steps::new();
 
     steps.when_regex_async(
-        r#"the machine manager server asks machine for proof on cycle (\d+) for address (\d+) with log2_size (\d+)"#,
+        r#"the machine manager server asks machine for proof on cycle (\d+) and ucycle (\d+) for address (\d+) with log2_size (\d+)"#,
     t!(|mut world, ctx| {
         let request = world.client_proxy.build_new_session_get_proof_request(
             ctx.matches[1].parse::<u64>().unwrap(),
             ctx.matches[2].parse::<u64>().unwrap(),
-            ctx.matches[3].parse::<u64>().unwrap());
+            ctx.matches[3].parse::<u64>().unwrap(),
+            ctx.matches[4].parse::<u64>().unwrap());
         match world.client_proxy.grpc_client.as_mut().unwrap().session_get_proof(request.clone()).await {
             Ok(val) => {
                 let verification_request = world.machine_proxy.build_get_proof_request(request);
@@ -59,7 +60,7 @@ pub fn steps() -> Steps<TestWorld> {
                     Box::new(verification_response.unwrap().into_inner().proof.unwrap()));
                 world.response.insert(String::from("response"), Box::new(val.into_inner()))
             },
-            Err(e) => panic!("Unable to perform get_proof request: {}", e),
+            Err(e) => world.response.insert(String::from("error"), Box::new(e))
         };
         world
     }));

--- a/tests/rust-test-client/tests/steps/session_read_write_memory.rs
+++ b/tests/rust-test-client/tests/steps/session_read_write_memory.rs
@@ -19,12 +19,13 @@ pub fn steps() -> Steps<TestWorld> {
     let mut steps: Steps<TestWorld> = Steps::new();
 
     steps.given_regex_async(
-        r#"the write request executed for cycle (\d+), starting address (\d+) and data (.+)"#,
+        r#"the write request executed for cycle (\d+) and ucycle (\d+), starting address (\d+) and data (.+)"#,
         t!(|mut world, ctx| {
             let request = world.client_proxy.build_new_session_write_memory_request(
                 ctx.matches[1].parse::<u64>().unwrap(),
                 ctx.matches[2].parse::<u64>().unwrap(),
-                ctx.matches[3].as_bytes().to_vec(),
+                ctx.matches[3].parse::<u64>().unwrap(),
+                ctx.matches[4].as_bytes().to_vec(),
             );
             let cl = world.client_proxy.grpc_client.as_mut().unwrap();
             if let Err(e) = cl.session_write_memory(request).await {
@@ -35,12 +36,13 @@ pub fn steps() -> Steps<TestWorld> {
     );
 
     steps.when_regex_async(
-        r#"client asks server to read memory on cycle (\d+), starting on address (\d+) for length (\d+)"#,
+        r#"client asks server to read memory on cycle (\d+) and ucycle (\d+), starting on address (\d+) for length (\d+)"#,
     t!(|mut world, ctx| {
         let request = world.client_proxy.build_new_session_read_memory_request(
             ctx.matches[1].parse::<u64>().unwrap(),
             ctx.matches[2].parse::<u64>().unwrap(),
-            ctx.matches[3].parse::<u64>().unwrap());
+            ctx.matches[3].parse::<u64>().unwrap(),
+            ctx.matches[4].parse::<u64>().unwrap());
         match world.client_proxy.grpc_client.as_mut().unwrap().session_read_memory(request).await {
             Ok(val) => world.response.insert(String::from("response"), Box::new(val.into_inner())),
             Err(e) => world.response.insert(String::from("error"), Box::new(e)),
@@ -49,11 +51,12 @@ pub fn steps() -> Steps<TestWorld> {
     }));
 
     steps.when_regex_async(
-        r#"client asks server to write data (.+) on cycle (\d+), starting on address (\d+)"#,
+        r#"client asks server to write data (.+) on cycle (\d+) and ucycle (\d+), starting on address (\d+)"#,
         t!(|mut world, ctx| {
             let request = world.client_proxy.build_new_session_write_memory_request(
                 ctx.matches[2].parse::<u64>().unwrap(),
                 ctx.matches[3].parse::<u64>().unwrap(),
+                ctx.matches[4].parse::<u64>().unwrap(),
                 ctx.matches[1].as_bytes().to_vec(),
             );
             if let Err(e) = world

--- a/tests/rust-test-client/tests/steps/session_store_load.rs
+++ b/tests/rust-test-client/tests/steps/session_store_load.rs
@@ -77,16 +77,19 @@ pub fn steps() -> Steps<TestWorld> {
     );
 
     steps.then_regex_async(
-        r#"machine manager server is able to execute this machine for (\d+) cycles"#,
+        r#"machine manager server is able to execute this machine for (\d+) cycles and (\d+) ucycles"#,
         t!(|mut world, ctx| {
+            let cycles = vec![ctx.matches[1].parse::<u64>().unwrap()];
+            let ucycles = vec![ctx.matches[2].parse::<u64>().unwrap()];
             let ret = run_machine(
-                vec![ctx.matches[1].parse::<u64>().unwrap()],
+                &cycles,
+                &ucycles,
                 &mut world.client_proxy,
             )
             .await;
             if let session_run_response::RunOneof::Result(result) = ret.run_oneof.as_ref().unwrap()
             {
-                get_verification_hashes(&mut world, vec![ctx.matches[1].parse::<u64>().unwrap()])
+                get_verification_hashes(&mut world, &cycles, &ucycles)
                     .await;
                 let result_hashes: Vec<Hash> = result.hashes.clone();
                 world


### PR DESCRIPTION
1. All machine manager and session API methods accpet ucycles as parameter and check for requested ucycle to be equal to session ucycle.
2. Run method calls machine.run_uarch and machine.reset_uarch_state.
3. Step method calls machine.reset_uarch_state and work only with ucycles.
4. MachineClientProxy, used verification runs, now have step_uarch and run_to methods, which have the same implementation as machine manager methods.
5. Existing test cases updated to use ucycle values.
6. Add new test cases to catch invalid cycle and ucycle values.
7. Add new test cases to verify session current cycle and ucycle after execuiton of step or run.